### PR TITLE
Update utils.jl

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -13,7 +13,7 @@ function selectbypeakdistance(pkindices, priority, distance)
     npkindices = length(pkindices)
     keep = trues(npkindices)
 
-    prioritytoposition = fsortperm(priority)
+    prioritytoposition = sortperm(priority)
     for i ∈ npkindices:-1:1
         j = prioritytoposition[i]
         iszero(keep[j]) && continue


### PR DESCRIPTION
Using fsortperm() throws `MethodError: no method matching uint_mapping(::Base.Order.ForwardOrdering, ::Float64)` when distance !== nothing. Replacing fsortperm() with sortperm() solves the error.